### PR TITLE
Use the real url for topological inventory

### DIFF
--- a/lib/topological_inventory/operations/openshift/core/retriever.rb
+++ b/lib/topological_inventory/operations/openshift/core/retriever.rb
@@ -26,8 +26,7 @@ module TopologicalInventory
           end
 
           def base_url
-            # "http://#{ENV["TOPOLOGICAL_INVENTORY_API_SERVICE_HOST"]}:#{ENV["TOPOLOGICAL_INVENTORY_API_SERVICE_PORT"]}/#{ENV["PATH_PREFIX"]}/topological-inventory/v0.0/"
-            "http://localhost:3000/api/v0.0/"
+            "http://#{ENV["TOPOLOGICAL_INVENTORY_API_SERVICE_HOST"]}:#{ENV["TOPOLOGICAL_INVENTORY_API_SERVICE_PORT"]}/#{ENV["PATH_PREFIX"]}/topological-inventory/v0.0/"
           end
 
           def url_path


### PR DESCRIPTION
This would fail quite hard when deployed currently.

cc @eclarizio do you want to have another way to override this or can you make this work for local development?