### PR TITLE
Change database names in template to match API repo

### DIFF
--- a/config/database.dev.yml
+++ b/config/database.dev.yml
@@ -10,13 +10,13 @@ default: &default
 
 development:
   <<: *default
-  database: topological_inventory_operations-openshift_development
+  database: topological_inventory_development
   min_messages: notice
 
 test:
   <<: *default
-  database: topological_inventory_operations-openshift_test
+  database: topological_inventory_test
 
 production:
   <<: *default
-  database: topological_inventory_operations-openshift_production
+  database: topological_inventory_production


### PR DESCRIPTION
@carbonin Pointed out to me that this repo doesn't need its own database, and when it does need to pull from the db it should be using the same database that the API repository uses.

Eventually, this repository won't even need the database at all (except maybe for specs? But we can probably just switch to using doubles), but this will work for now.