### PR TITLE
[WIP] Replace most RestClient calls with topological_inventory-api-client

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -3,6 +3,7 @@ source 'https://rubygems.org'
 gem "manageiq-messaging", '~> 0.1.2'
 
 gem "topological_inventory-core", :git => "https://github.com/ManageIQ/topological_inventory-core", :branch => "master"
+gem 'topological_inventory-api-client', :git => "https://github.com/eclarizio/topological_inventory-api-client", :branch => "master"
 
 group :development do
   gem "rspec-rails", "~>3.8"

--- a/lib/topological_inventory/operations/openshift/core/retriever.rb
+++ b/lib/topological_inventory/operations/openshift/core/retriever.rb
@@ -1,3 +1,5 @@
+require "topological_inventory-api-client"
+
 module TopologicalInventory
   module Operations
     module Openshift
@@ -5,32 +7,18 @@ module TopologicalInventory
         class Retriever
           def initialize(id)
             @id = id
+            uri = URI.parse(ENV["TOPOLOGICAL_INVENTORY_URL"])
+            TopologicalInventoryApiClient.configure do |config|
+              config.base_path = "#{ENV["PATH_PREFIX"]}/topological-inventory/v0.0/"
+              config.scheme = uri.scheme
+              config.host = "#{uri.host}:#{uri.port}"
+            end
+
+            @api_instance = TopologicalInventoryApiClient::DefaultApi.new
           end
 
           def process
-            JSON.parse(RestClient::Request.new(request_options).execute)
-          end
-
-          private
-
-          def headers
-            {"Content-Type" => "application/json"}
-          end
-
-          def request_options
-            {
-              :method  => :get,
-              :url     => base_url + url_path,
-              :headers => headers
-            }
-          end
-
-          def base_url
-            "#{ENV["TOPOLOGICAL_INVENTORY_URL"]}/#{ENV["PATH_PREFIX"]}/topological-inventory/v0.0/"
-          end
-
-          def url_path
-            nil #Override in subclasses
+            nil # Override in subclasses
           end
         end
       end

--- a/lib/topological_inventory/operations/openshift/core/service_catalog_client.rb
+++ b/lib/topological_inventory/operations/openshift/core/service_catalog_client.rb
@@ -10,9 +10,9 @@ module TopologicalInventory
         class ServiceCatalogClient
           def initialize(source_id)
             all_source_endpoints = SourceEndpointsRetriever.new(source_id).process
-            @default_endpoint = all_source_endpoints.find { |endpoint| endpoint["default"] }
+            @default_endpoint = all_source_endpoints.data.find { |endpoint| endpoint.default }
 
-            @authentication = AuthenticationRetriever.new(@default_endpoint["id"]).process
+            @authentication = AuthenticationRetriever.new(@default_endpoint.id).process
           end
 
           def order_service_plan(plan_name, service_offering_name, additional_parameters)
@@ -25,10 +25,10 @@ module TopologicalInventory
 
           def order_service_plan_url
             base_url_path = URI::Generic.build(
-              :scheme => @default_endpoint["scheme"],
-              :host   => @default_endpoint["host"],
-              :port   => @default_endpoint["port"],
-              :path   => @default_endpoint["path"]
+              :scheme => @default_endpoint.scheme,
+              :host   => @default_endpoint.host,
+              :port   => @default_endpoint.port,
+              :path   => @default_endpoint.path
             ).to_s
             URI.join(base_url_path, "apis/servicecatalog.k8s.io/v1beta1/namespaces/default/serviceinstances").to_s
           end
@@ -54,7 +54,7 @@ module TopologicalInventory
           end
 
           def verify_ssl_mode
-            @default_endpoint["verify_ssl"] ? OpenSSL::SSL::VERIFY_PEER : OpenSSL::SSL::VERIFY_NONE
+            @default_endpoint.verify_ssl ? OpenSSL::SSL::VERIFY_PEER : OpenSSL::SSL::VERIFY_NONE
           end
         end
       end

--- a/lib/topological_inventory/operations/openshift/core/service_offering_retriever.rb
+++ b/lib/topological_inventory/operations/openshift/core/service_offering_retriever.rb
@@ -5,10 +5,8 @@ module TopologicalInventory
     module Openshift
       module Core
         class ServiceOfferingRetriever < Retriever
-          private
-
-          def url_path
-            "service_offerings/#{@id}"
+          def process
+            @api_instance.show_service_offering(@id.to_s)
           end
         end
       end

--- a/lib/topological_inventory/operations/openshift/core/service_plan_retriever.rb
+++ b/lib/topological_inventory/operations/openshift/core/service_plan_retriever.rb
@@ -5,10 +5,8 @@ module TopologicalInventory
     module Openshift
       module Core
         class ServicePlanRetriever < Retriever
-          private
-
-          def url_path
-            "service_plans/#{@id}"
+          def process
+            @api_instance.show_service_plan(@id.to_s)
           end
         end
       end

--- a/lib/topological_inventory/operations/openshift/core/source_endpoints_retriever.rb
+++ b/lib/topological_inventory/operations/openshift/core/source_endpoints_retriever.rb
@@ -5,10 +5,8 @@ module TopologicalInventory
     module Openshift
       module Core
         class SourceEndpointsRetriever < Retriever
-          private
-
-          def url_path
-            "sources/#{@id}/endpoints"
+          def process
+            @api_instance.list_source_endpoints(@id.to_s)
           end
         end
       end

--- a/lib/topological_inventory/operations/openshift/core/source_retriever.rb
+++ b/lib/topological_inventory/operations/openshift/core/source_retriever.rb
@@ -5,10 +5,8 @@ module TopologicalInventory
     module Openshift
       module Core
         class SourceRetriever < Retriever
-          private
-
-          def url_path
-            "sources/#{@id}"
+          def process
+            @api_instance.show_source(@id.to_s)
           end
         end
       end

--- a/lib/topological_inventory/operations/openshift/worker.rb
+++ b/lib/topological_inventory/operations/openshift/worker.rb
@@ -49,15 +49,15 @@ module TopologicalInventory
 
         def order_service(service_plan_id, order_params)
           service_plan = Core::ServicePlanRetriever.new(service_plan_id).process
-          source = Core::SourceRetriever.new(service_plan["source_id"]).process
-          service_offering = Core::ServiceOfferingRetriever.new(service_plan["service_offering_id"]).process
+          source = Core::SourceRetriever.new(service_plan.source_id).process
+          service_offering = Core::ServiceOfferingRetriever.new(service_plan.service_offering_id).process
 
-          catalog_client = Core::ServiceCatalogClient.new(source["id"])
-          parsed_response = catalog_client.order_service_plan(service_plan["name"], service_offering["name"], order_params)
+          catalog_client = Core::ServiceCatalogClient.new(source.id)
+          parsed_response = catalog_client.order_service_plan(service_plan.name, service_offering.name, order_params)
 
           {
             :service_instance => {
-              :source_id  => source["id"],
+              :source_id  => source.id,
               :source_ref => parsed_response['metadata']['selfLink']
             }
           }
@@ -70,7 +70,7 @@ module TopologicalInventory
           payload = {
             "status"  => "completed",
             "context" => context
-          }
+          }.to_json
           request_options = {
             :method     => :post,
             :url        => "#{ENV["TOPOLOGICAL_INVENTORY_URL"]}/#{ENV["PATH_PREFIX"]}/topological-inventory/v0.0/tasks/#{task_id}",

--- a/spec/operations/openshift/core/service_offering_retriever_spec.rb
+++ b/spec/operations/openshift/core/service_offering_retriever_spec.rb
@@ -10,10 +10,10 @@ module TopologicalInventory
           describe "#process" do
             let(:url) { "http://localhost:3000/api/topological-inventory/v0.0/service_offerings/123" }
             let(:headers) { {"Content-Type" => "application/json"} }
-            let(:dummy_response) { {"dummy" => "response"} }
+            let(:dummy_response) { {"name" => "dummy"} }
 
             before do
-              stub_request(:get, url).with(:headers => headers).to_return(:body => dummy_response.to_json)
+              stub_request(:get, url).with(:headers => headers).to_return(:body => dummy_response.to_json, :headers => headers)
             end
 
             around do |e|
@@ -30,7 +30,9 @@ module TopologicalInventory
             end
 
             it "returns the service offering response" do
-              expect(subject.process).to eq(dummy_response)
+              service_offering = subject.process
+              expect(service_offering.class).to eq(TopologicalInventoryApiClient::ServiceOffering)
+              expect(service_offering.name).to eq("dummy")
             end
           end
         end

--- a/spec/operations/openshift/core/service_plan_retriever_spec.rb
+++ b/spec/operations/openshift/core/service_plan_retriever_spec.rb
@@ -10,10 +10,10 @@ module TopologicalInventory
           describe "#process" do
             let(:url) { "http://localhost:3000/api/topological-inventory/v0.0/service_plans/123" }
             let(:headers) { {"Content-Type" => "application/json"} }
-            let(:dummy_response) { {"dummy" => "response"} }
+            let(:dummy_response) { {"name" => "dummy"} }
 
             before do
-              stub_request(:get, url).with(:headers => headers).to_return(:body => dummy_response.to_json)
+              stub_request(:get, url).with(:headers => headers).to_return(:body => dummy_response.to_json, :headers => headers)
             end
 
             around do |e|
@@ -30,7 +30,9 @@ module TopologicalInventory
             end
 
             it "returns the service plan response" do
-              expect(subject.process).to eq(dummy_response)
+              service_plan = subject.process
+              expect(service_plan.class).to eq(TopologicalInventoryApiClient::ServicePlan)
+              expect(service_plan.name).to eq("dummy")
             end
           end
         end

--- a/spec/operations/openshift/core/source_endpoints_retriever_spec.rb
+++ b/spec/operations/openshift/core/source_endpoints_retriever_spec.rb
@@ -10,10 +10,10 @@ module TopologicalInventory
           describe "#process" do
             let(:url) { "http://localhost:3000/api/topological-inventory/v0.0/sources/123/endpoints" }
             let(:headers) { {"Content-Type" => "application/json"} }
-            let(:dummy_response) { {"dummy" => "response"} }
+            let(:dummy_response) { {"data" => [{"host" => "dummy"}]} }
 
             before do
-              stub_request(:get, url).with(:headers => headers).to_return(:body => dummy_response.to_json)
+              stub_request(:get, url).with(:headers => headers).to_return(:body => dummy_response.to_json, :headers => headers)
             end
 
             around do |e|
@@ -29,8 +29,11 @@ module TopologicalInventory
               ENV["PATH_PREFIX"]               = prefix
             end
 
-            it "returns the service plan response" do
-              expect(subject.process).to eq(dummy_response)
+            it "returns the list of endpoints based on the source" do
+              endpoints = subject.process
+              expect(endpoints.class).to eq(TopologicalInventoryApiClient::EndpointsCollection)
+              expect(endpoints.data.first.class).to eq(TopologicalInventoryApiClient::Endpoint)
+              expect(endpoints.data.first.host).to eq("dummy")
             end
           end
         end

--- a/spec/operations/openshift/core/source_retriever_spec.rb
+++ b/spec/operations/openshift/core/source_retriever_spec.rb
@@ -10,10 +10,10 @@ module TopologicalInventory
           describe "#process" do
             let(:url) { "http://localhost:3000/api/topological-inventory/v0.0/sources/123" }
             let(:headers) { {"Content-Type" => "application/json"} }
-            let(:dummy_response) { {"dummy" => "response"} }
+            let(:dummy_response) { {"name" => "dummy"} }
 
             before do
-              stub_request(:get, url).with(:headers => headers).to_return(:body => dummy_response.to_json)
+              stub_request(:get, url).with(:headers => headers).to_return(:body => dummy_response.to_json, :headers => headers)
             end
 
             around do |e|
@@ -30,7 +30,9 @@ module TopologicalInventory
             end
 
             it "returns the source response" do
-              expect(subject.process).to eq(dummy_response)
+              source = subject.process
+              expect(source.class).to eq(TopologicalInventoryApiClient::Source)
+              expect(source.name).to eq("dummy")
             end
           end
         end


### PR DESCRIPTION
The remaining `RestClient` call is for updating the task, which will be handled with a separate PR.

I'm currently using my branch of the `topological_inventory-api-client` because it is updated with the `verify_ssl` property for the `Endpoint` model, and it also includes the PATCH route for tasks for the other separate PR.

So, due to the above, I'll mark this WIP until we figure out if we are ok with simply using my branch for now or if we want to migrate to manageiq first.